### PR TITLE
Update integration.md

### DIFF
--- a/devnet/integration.md
+++ b/devnet/integration.md
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 // The main function that executes the prover program.
-fn run_task(task: &Task) -> Result<TaskResult, Box<dyn Error>> {
+fn run_task(task: Task) -> Result<TaskResult, Box<dyn Error>> {
     // Display program arguments we received. These could be used for
     // e.g. parsing CLI arguments with clap.
     println!("prover: task.args: {:?}", &task.args);


### PR DESCRIPTION
Needed to get `cargo c` to pass for https://github.com/nuke-web3/r0-prover-on-gevulot-example/blob/fe6bb756f44d06ab080f247527d34c445d316cb5/src/main.rs#L10